### PR TITLE
feat: verify that the downloaded binary is created and signed by HashiCorp before installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Set up your GitHub Actions workflow with a specific version of Terraform.
 This action sets up [Terraform CLI](https://www.terraform.io/) in your GitHub Actions workflow by:
 
 - Downloading a specified version of Terraform CLI and adding it to the 'PATH'
+- Verifying that the downloaded binary is created and signed by HashiCorp before installation
 
 This enables Terraform CLI commands to execute just like they do on your local environment.
 

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,7 @@ description: |
   This action sets up [Terraform CLI](https://www.terraform.io/) in your GitHub Actions workflow by:
 
   - Downloading a specified version of Terraform CLI and adding it to the 'PATH'
+  - Verifying that the downloaded binary is created and signed by HashiCorp before installation
 
   This enables Terraform CLI commands to execute just like they do on your local environment.
 
@@ -38,6 +39,21 @@ runs:
         echo "::endgroup::"
       shell: bash
 
+    # Security at HashiCorp
+    # https://www.hashicorp.com/trust/security
+    - name: Import PGP public key
+      working-directory: ${{ steps.install.outputs.path }}
+      run: |
+        echo "::group::Import PGP public key"
+        set -x
+        key_file="pgp-key.txt"
+        curl -sSLO "https://www.hashicorp.com/.well-known/${key_file}"
+        gpg --import "${key_file}"
+        echo "::endgroup::"
+      shell: bash
+
+    # Verify HashiCorp binary downloads
+    # https://developer.hashicorp.com/well-architected-framework/operational-excellence/verify-hashicorp-binary
     - name: Install Terraform
       working-directory: ${{ steps.install.outputs.path }}
       env:
@@ -46,10 +62,22 @@ runs:
         echo "::group::Install Terraform"
         set -x
         archive_file="terraform_${VERSION}_linux_amd64.zip"
+        checksum_file="terraform_${VERSION}_SHA256SUMS"
+        signature_file="terraform_${VERSION}_SHA256SUMS.sig"
+
+        # Download archive, checksum, and signature files
         base_url="https://releases.hashicorp.com/terraform/${VERSION}"
         curl -sSLO "${base_url}/${archive_file}"
+        curl -sSLO "${base_url}/${checksum_file}"
+        curl -sSLO "${base_url}/${signature_file}"
 
-        # Install binary and set path
+        # Verify signature and checksum files
+        gpg --verify "${signature_file}" "${checksum_file}"
+
+        # Verify checksum and archive files
+        grep "${archive_file}" "${checksum_file}" | sha256sum --check
+
+        # Install binary and set path variables
         bin_path="${PWD}/bin"
         mkdir -p "${bin_path}"
         unzip "${PWD}/${archive_file}" -d "${bin_path}"


### PR DESCRIPTION
## Verify Process

1. Download and import the PGP public key.
2. Download the archive, checksum, and signature files.
3. Verify the signature and checksum files using the `gpg` command.
4. Verify the checksum and archive files using the `sha256sum` command.
5. Install the binary file and set the `PATH` variables.

## Reference

- Verify HashiCorp binary downloads
    - https://developer.hashicorp.com/well-architected-framework/operational-excellence/verify-hashicorp-binary
- Security at HashiCorp
    - https://www.hashicorp.com/trust/security

## Troubleshooting Error Messages

### gpg: Can't check signature: No public key

You may receive the following error when attempting to run the `gpg --verify` command.

```shell
+ gpg --verify terraform_1.2.3_SHA256SUMS.sig terraform_1.2.3_SHA256SUMS

gpg: Signature made Mon Mar 20 18:09:34 2023 UTC
gpg:                using RSA key 374EC75B485913604A831CC7C820C6D5CD27AB87
gpg: Can't check signature: No public key
```

#### Steps to Reproduce

Import a PGP public key other than HashiCorp's (for example, Google’s).

```shell
# curl -sSLO "https://www.hashicorp.com/.well-known/${key_file}"
# gpg --import "${key_file}"
curl -sSLO https://dl.google.com/linux/linux_signing_key.pub
gpg --import "linux_signing_key.pub"
```

#### Possible Cause: Correct PGP Public Key Is Not Imported

The correct PGP public key may not have been imported.
Please confirm that the imported PGP public key is correct.
You can download the correct PGP public key from the following URL:

- https://www.hashicorp.com/.well-known/pgp-key.txt

For the latest information on PGP public keys, refer to:

- https://www.hashicorp.com/trust/security

#### Possible Cause: Tampered Signature File

While the error is primarily due to the missing public key,
there’s also a possibility that the signature or checksum file has been tampered with.
Check if HashiCorp has announced any security incidents.

### gpg: BAD signature from "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>"

You may receive the following error when attempting to run the `gpg --verify` command.

```shell
+ gpg --verify terraform_1.2.3_SHA256SUMS.sig terraform_1.2.3_SHA256SUMS

gpg: Signature made Mon Mar 20 18:09:26 2023 UTC
gpg:                using RSA key 374EC75B485913604A831CC7C820C6D5CD27AB87
gpg: BAD signature from "HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>" [unknown]
```

#### Steps to Reproduce

Use a different version’s signature file for verification.

```shell
# curl -sSLO "${base_url}/${signature_file}"
signature_file="terraform_1.2.2_SHA256SUMS.sig"
curl -sSLO "https://releases.hashicorp.com/terraform/1.2.2/terraform_1.2.2_SHA256SUMS.sig"
gpg --verify terraform_1.2.2_SHA256SUMS.sig terraform_1.2.3_SHA256SUMS
```

#### Possible Cause: Incorrect Signature File

The signature file may not correspond to the checksum file.
Ensure that the signature and checksum file pair specified as arguments for the `gpg --verify` command is correct.

#### Possible Cause: Tampered Checksum File

The checksum file may have been altered, causing the signature to no longer match.
Check if HashiCorp has announced any security incidents.

#### Possible Cause: Expired PGP Public Key

The PGP public key used for signing may have expired, making the signature invalid.
Verify that a valid PGP public key has been published by HashiCorp.
For the latest PGP public key information, refer to:

- https://www.hashicorp.com/trust/security

### sha256sum: WARNING: 1 computed checksum did NOT match

You may receive the following error when attempting to run the `sha256sum --check` command.

```shell
+ grep "${archive_file}" "${checksum_file}" | sha256sum --check

sha256sum: WARNING: 1 computed checksum did NOT match
terraform_1.2.3_linux_amd64.zip: FAILED
```

#### Steps to Reproduce

Rename a different archive file and attempt to verify the checksum.

```shell
cp "${archive_file}" "terraform_1.2.3_darwin_amd64.zip"
grep "terraform_1.2.3_darwin_amd64.zip" "${checksum_file}" | sha256sum --check
```

#### Possible Cause: Tampered File

The downloaded file may have been tampered with by a third party,
making it the wrong version and causing checksum verification to fail.
Check if HashiCorp has announced any security incidents.

#### Possible Cause: Incorrect Checksum

The checksum in the `terraform_X.Y.Z_SHA256SUMS` file may not match the actual hash of the `terraform_X.Y.Z_linux_amd64.zip` file.
This could be due to an incorrect or tampered checksum file.
Check if HashiCorp has announced any security incidents.
