### PR TITLE
fix: verify that the PGP public key is created by HashiCorp

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,11 +43,29 @@ runs:
     # https://www.hashicorp.com/trust/security
     - name: Import PGP public key
       working-directory: ${{ steps.install.outputs.path }}
+      env:
+        EXPECTED_FINGERPRINT: C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F
       run: |
         echo "::group::Import PGP public key"
         set -x
         key_file="pgp-key.txt"
         curl -sSLO "https://www.hashicorp.com/.well-known/${key_file}"
+
+        # pub   rsa4096 2021-04-19 [SC] [expires: 2026-04-18]
+        #       C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
+        # uid                      HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>
+        # sub   rsa4096 2021-04-19 [E] [expires: 2026-04-18]
+        # sub   rsa4096 2021-04-19 [S] [expired: 2022-04-20]
+        # sub   rsa4096 2021-04-21 [S] [expires: 2026-04-20]
+        key_info="$(gpg --with-fingerprint --show-keys "${key_file}")"
+
+        # Verify and import PGP public key
+        fingerprint="$(grep -A 1 "pub " <<<"${key_info}" | tail -1 | sed 's/^[[:space:]]*//' | tr -s ' ')"
+        if [[ "${fingerprint}" != "${EXPECTED_FINGERPRINT}" ]]; then
+          message="actual fingerprint: '${fingerprint}', see details https://www.hashicorp.com/trust/security"
+          echo "::error title=Invalid PGP public key::${message}"
+          exit 1
+        fi
         gpg --import "${key_file}"
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
## Description

Use the PGP public key fingerprint provided in the "Security at HashiCorp" link below:

- https://www.hashicorp.com/trust/security

As of November 1, 2024, here is the content directly from the "PGP public key" section:

> HashiCorp’s current PGP public key can be fetched from Keybase or from most keyservers with the key ID `72D7468F` and fingerprint `C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F`. It is also available at https://www.hashicorp.com/.well-known/pgp-key.txt.

### Screenshot

> <img width="809" alt="screen_shot" src="https://github.com/user-attachments/assets/52ef3329-a7d1-463c-8a86-3ac4b5467175">
> https://www.hashicorp.com/trust/security


## Steps for Retrieving the Fingerprint

1. Use `gpg --with-fingerprint --show-keys "${key_file}"` to store the output in the `key_info` variable.

```shell
pub   rsa4096 2021-04-19 [SC] [expires: 2026-04-18]
      C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
uid                      HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>
sub   rsa4096 2021-04-19 [E] [expires: 2026-04-18]
sub   rsa4096 2021-04-19 [S] [expired: 2022-04-20]
sub   rsa4096 2021-04-21 [S] [expires: 2026-04-20]
```

2. Use `grep -A 1 "pub " <<<"${key_info}"` to retrieve the public key section.

```shell
pub   rsa4096 2021-04-19 [SC] [expires: 2026-04-18]
      C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
```

3. Use `tail -1` to isolate the fingerprint line.

```shell
      C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
```

4. Use `sed 's/^[[:space:]]*//'` to remove leading spaces.

```shell
C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F
```

5. Use `tr -s ' '` to replace double spaces with a single space.

```shell
C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F
```

Let’s take another look at the output values from Steps 4 and 5 and compare them.

- Step 4: `C874 011F 0AB4 0511 0D02  1055 3436 5D94 72D7 468F`
- Step 5: `C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F`

As you can see, there are two spaces in the middle in Step 4.
This is why, in Step 5, the double spaces are replaced with a single space.
