### PR TITLE
feat: enable provider plugin cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,69 @@ jobs:
         run: |
           set -x
           test "$(terraform -version | head -n 1)" = 'Terraform v1.2.3'
+
+  test-plugin-cache:
+    name: Test plugin cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: tmknom/checkout-action@v1
+
+      - name: Setup
+        id: setup
+        run: |
+          set -x
+          test_dir="${RUNNER_TEMP}/${GITHUB_JOB}/${GITHUB_RUN_ID}"
+
+          mkdir -p "${test_dir}/no-cache"
+          echo "no-cache-dir=${test_dir}/no-cache" >> "${GITHUB_OUTPUT}"
+          cat <<EOF >"${test_dir}/no-cache/main.tf"
+          terraform {
+            required_providers {
+              aws = {
+                source  = "hashicorp/aws"
+                version = "5.74.0"
+              }
+            }
+          }
+          EOF
+
+          mkdir -p "${test_dir}/cache"
+          echo "cache-dir=${test_dir}/cache" >> "${GITHUB_OUTPUT}"
+          cat <<EOF >"${test_dir}/cache/main.tf"
+          terraform {
+            required_providers {
+              aws = {
+                source  = "hashicorp/aws"
+                version = "5.74.0"
+              }
+            }
+          }
+          EOF
+
+      - name: Exercise
+        id: exercise
+        uses: ./
+        with:
+          terraform-version: 1.2.3
+
+      - name: Verify no cached
+        working-directory: ${{ steps.setup.outputs.no-cache-dir }}
+        run: |
+          set -x
+          pwd
+          cat main.tf
+          terraform init | tee -a init.log
+          grep "Installed hashicorp/aws v5.74.0 (signed by HashiCorp)" init.log
+
+      - name: Verify cached
+        working-directory: ${{ steps.setup.outputs.cache-dir }}
+        run: |
+          set -x
+          pwd
+          cat main.tf
+          terraform init | tee -a init.log
+          grep "Using hashicorp/aws v5.74.0 from the shared cache directory" init.log

--- a/action.yml
+++ b/action.yml
@@ -104,6 +104,19 @@ runs:
         echo "::endgroup::"
       shell: bash
 
+    # Provider Plugin Cache
+    # https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
+    - name: Setup plugin cache dir
+      working-directory: ${{ steps.install.outputs.path }}
+      run: |
+        echo "::group::Install Terraform"
+        set -x
+        cache_dir="${PWD}/.terraform.d/plugin-cache"
+        mkdir -p "${cache_dir}"
+        echo "TF_PLUGIN_CACHE_DIR=${cache_dir}" >> "${GITHUB_ENV}"
+        echo "::endgroup::"
+      shell: bash
+
     - name: Log details
       if: ${{ failure() || runner.debug }}
       working-directory: ${{ steps.install.outputs.path }}


### PR DESCRIPTION
By default, `terraform init` downloads plugins into a subdirectory
of the working directory so that each working directory is self-contained.

But enable the plugin cache,
then allows each distinct plugin binary to be downloaded only once.

This contributes to speeding up the `terraform init` command
when it is executed many times in a workflow.

See details:

- https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache