### PR TITLE
feat: add support for latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,27 @@ jobs:
           set -x
           test "$(terraform -version | head -n 1)" = 'Terraform v1.2.3'
 
+  test-latest-version:
+    name: Test latest version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: tmknom/checkout-action@v1
+
+      - name: Exercise
+        uses: ./
+        with:
+          terraform-version: latest
+
+      - name: Verify
+        run: |
+          set -x
+          json="$(terraform version -json)"
+          test "$(jq -r '.terraform_outdated' <<<"${json}")" = 'false'
+
   test-plugin-cache:
     name: Test plugin cache
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,23 @@ runs:
   using: composite
 
   steps:
+    - name: Determine install version
+      id: version
+      env:
+        TERRAFORM_VERSION: ${{ inputs.terraform-version }}
+      run: |
+        echo "::group::Determine install version"
+        set -x
+        version="${TERRAFORM_VERSION}"
+        if [[ "${TERRAFORM_VERSION}" == "latest" ]]; then
+          api_url="https://api.github.com/repos/hashicorp/terraform/releases/latest"
+          version="$(curl --silent --show-error "${api_url}" | jq -r '.tag_name')"
+        fi
+        no_prefix="${version/v/}"
+        echo "number=${no_prefix}" >> "${GITHUB_OUTPUT}"
+        echo "::endgroup::"
+      shell: bash
+
     - name: Create install dir
       id: install
       run: |
@@ -77,7 +94,7 @@ runs:
     - name: Install Terraform
       working-directory: ${{ steps.install.outputs.path }}
       env:
-        VERSION: ${{ inputs.terraform-version }}
+        VERSION: ${{ steps.version.outputs.number }}
       run: |
         echo "::group::Install Terraform"
         set -x


### PR DESCRIPTION
Change the input parameter `terraform-version` to allow `latest` to be specified.
If `latest` is specified, the latest stable version will be installed.