### PR TITLE
feat: add support for ommit terraform version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,25 @@ jobs:
           json="$(terraform version -json)"
           test "$(jq -r '.terraform_outdated' <<<"${json}")" = 'false'
 
+  test-omit-version:
+    name: Test omit version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: tmknom/checkout-action@v1
+
+      - name: Exercise
+        uses: ./
+
+      - name: Verify
+        run: |
+          set -x
+          json="$(terraform version -json)"
+          test "$(jq -r '.terraform_outdated' <<<"${json}")" = 'false'
+
   test-plugin-cache:
     name: Test plugin cache
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ description: |
 
 inputs:
   terraform-version:
+    default: latest
     required: false
     description: The version of Terraform CLI to install.
 


### PR DESCRIPTION
If the input parameter `terraform-version` is omitted,
the `latest` version is automatically installed.