### PR TITLE
fix: use fail option in curl

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,9 +106,9 @@ runs:
 
         # Download archive, checksum, and signature files
         base_url="https://releases.hashicorp.com/terraform/${VERSION}"
-        curl --silent --show-error --location --remote-name "${base_url}/${archive_file}"
-        curl --silent --show-error --location --remote-name "${base_url}/${checksum_file}"
-        curl --silent --show-error --location --remote-name "${base_url}/${signature_file}"
+        curl --silent --show-error --fail --location --remote-name "${base_url}/${archive_file}"
+        curl --silent --show-error --fail --location --remote-name "${base_url}/${checksum_file}"
+        curl --silent --show-error --fail --location --remote-name "${base_url}/${signature_file}"
 
         # Verify signature and checksum files
         gpg --verify "${signature_file}" "${checksum_file}"


### PR DESCRIPTION
This flag prevents curl from outputting at all on server errors and return error 22.
