### PR TITLE
feat: add support for latest version in tfcmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,12 +57,19 @@ jobs:
         uses: ./
         with:
           terraform-version: latest
+          tfcmt-version: latest
 
-      - name: Verify
+      - name: Verify Terraform
         run: |
           set -x
           json="$(terraform version -json)"
           test "$(jq -r '.terraform_outdated' <<<"${json}")" = 'false'
+
+      - name: Verify tfcmt
+        run: |
+          set -x
+          actual="$(tfcmt --version)"
+          grep 'tfcmt version 4.' <<<"${actual}"
 
   test-omit-version:
     name: Test omit version
@@ -77,11 +84,17 @@ jobs:
       - name: Exercise
         uses: ./
 
-      - name: Verify
+      - name: Verify Terraform
         run: |
           set -x
           json="$(terraform version -json)"
           test "$(jq -r '.terraform_outdated' <<<"${json}")" = 'false'
+
+      - name: Verify tfcmt
+        run: |
+          set -x
+          actual="$(tfcmt --version)"
+          grep 'tfcmt version 4.' <<<"${actual}"
 
   test-plugin-cache:
     name: Test plugin cache

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Additionally, tfcmt simplifies commenting on the results of Terraform CLI comman
 | Name | Description | Default | Required |
 | :--- | :---------- | :------ | :------: |
 | terraform-version | The version of Terraform CLI to install. | `latest` | no |
-| tfcmt-version | The version of tfcmt to install. | n/a | no |
+| tfcmt-version | The version of tfcmt to install. | `latest` | no |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ inputs:
     required: false
     description: The version of Terraform CLI to install.
   tfcmt-version:
+    default: latest
     required: false
     description: The version of tfcmt to install.
 
@@ -62,6 +63,23 @@ runs:
         fi
         no_prefix="${version/v/}"
         echo "number=${no_prefix}" >> "${GITHUB_OUTPUT}"
+        echo "::endgroup::"
+      shell: bash
+
+    - name: Determine tfcmt version
+      id: tfcmt
+      env:
+        TFCMT_VERSION: ${{ inputs.tfcmt-version }}
+      run: |
+        echo "::group::Determine tfcmt version"
+        set -x
+        version="${TFCMT_VERSION}"
+        if [[ "${TFCMT_VERSION}" == "latest" ]]; then
+          api_url="https://api.github.com/repos/suzuki-shunsuke/tfcmt/releases/latest"
+          version="$(curl --silent --show-error "${api_url}" | jq -r '.tag_name')"
+        fi
+        no_prefix="${version/v/}"
+        echo "version=${no_prefix}" >> "${GITHUB_OUTPUT}"
         echo "::endgroup::"
       shell: bash
 
@@ -158,7 +176,7 @@ runs:
     - name: Install tfcmt
       working-directory: ${{ steps.work.outputs.dir }}
       env:
-        VERSION: ${{ inputs.tfcmt-version || '4.14.0' }}
+        VERSION: ${{ steps.tfcmt.outputs.version }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         echo "::group::Install tfcmt"


### PR DESCRIPTION
Change the input parameter `tfcmt-version` to allow `latest` to be specified.
If `latest` is specified, the latest stable version will be installed.